### PR TITLE
FIx Sigill Error on Linux

### DIFF
--- a/yaml/yaml.cpp
+++ b/yaml/yaml.cpp
@@ -106,6 +106,7 @@ namespace YAML {
 		if (this->m_children.find(nid) != this->m_children.end())
 			return false;
 		this->m_children.insert({ nid, node });
+		return true; //Fix SIGILL error
 	}
 	
 


### PR DESCRIPTION
Hello, this is a really good library.

I had an error where it the program would have a SIGILL error so I found that I just had to add a return true since its a boolean function. 